### PR TITLE
add support for Raspberry Pi 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ DEVICES = $(BUILDDIR)/devices/dspic33e.o \
 a10: CFLAGS += -DBOARD_A10
 raspberrypi: CFLAGS += -DBOARD_RPI
 raspberrypi2: CFLAGS += -DBOARD_RPI2
+rpi4b: CFLAGS += -DBOARD_RPI4B
 am335x: CFLAGS += -DBOARD_AM335X
 
 default:
@@ -33,6 +34,7 @@ default:
 
 raspberrypi: prepare picberry
 raspberrypi2: prepare picberry
+rpi4b: prepare picberry
 a10: prepare picberry
 am335x: prepare picberry gpio_test
 

--- a/src/common.h
+++ b/src/common.h
@@ -27,6 +27,8 @@
 #include "hosts/rpi.h"
 #elif defined(BOARD_RPI2)
 #include "hosts/rpi2.h"
+#elif defined(BOARD_RPI4B)
+#include "hosts/rpi4b.h"
 #elif defined(BOARD_AM335X)
 #include "hosts/am335x.h"
 #endif

--- a/src/hosts/rpi4b.h
+++ b/src/hosts/rpi4b.h
@@ -1,0 +1,39 @@
+/*
+ * Raspberry Pi PIC Programmer using GPIO connector
+ * https://github.com/WallaceIT/picberry
+ * Copyright 2016 Francesco Valla
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+/* GPIO registers address */
+#define BCM2708_PERI_BASE  0xFE000000
+#define GPIO_BASE          0xFE200000 /* GPIO controller */
+#define BLOCK_SIZE         (256)
+#define PORTOFFSET         0
+
+/* GPIO setup macros. Always use GPIO_IN(x) before using GPIO_OUT(x) */
+#define GPIO_IN(g)    *(gpio+((g&0xFF)/10))   &= ~(7<<(((g&0xFF)%10)*3))
+#define GPIO_OUT(g)   *(gpio+((g&0xFF)/10))   |=  (1<<(((g&0xFF)%10)*3))
+
+#define GPIO_SET(g)   *(gpio+7)  = 1<<(g&0xFF)
+#define GPIO_CLR(g)   *(gpio+10) = 1<<(g&0xFF)
+#define GPIO_LEV(g)   (*(gpio+13) >> (g&0xFF)) & 0x1 /* reads pin level */
+
+/* default GPIO <-> PIC connections */
+#define DEFAULT_PIC_CLK    23   /* PGC - Output */
+#define DEFAULT_PIC_DATA   24   /* PGD - I/O */
+#define DEFAULT_PIC_MCLR   18   /* MCLR - Output */


### PR DESCRIPTION
Only tested on RPI4B 8GB version using default GPIO pins... but since the only thing really different is the peri_base address, if it worked on rpi1-3, everything should be golden on rpi4.